### PR TITLE
Add analyzer package to help with API design suggestions

### DIFF
--- a/GDAPI/GDAPI/.editorconfig
+++ b/GDAPI/GDAPI/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# CA1062: Validate arguments of public methods
+dotnet_diagnostic.CA1062.severity = suggestion

--- a/GDAPI/GDAPI/GDAPI.csproj
+++ b/GDAPI/GDAPI/GDAPI.csproj
@@ -20,6 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System" />
     <PackageReference Include="System.CodeDom" />
     <PackageReference Include="System.Core" />


### PR DESCRIPTION
Most suggestions are out-of-context and trash, but we can at least harvest some useful tips that may appear once in a while.