### PR TITLE
Guideline fixes

### DIFF
--- a/GDAPI/GDAPI.Tests/Objects/GeometryDash/GuidelineCollectionTests.cs
+++ b/GDAPI/GDAPI.Tests/Objects/GeometryDash/GuidelineCollectionTests.cs
@@ -1,0 +1,51 @@
+﻿using GDAPI.Objects.GeometryDash.General;
+using NUnit.Framework;
+
+namespace GDAPI.Tests.Objects.GeometryDash
+{
+    public class GuidelineCollectionTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+        }
+
+        [Test]
+        public void Stringification()
+        {
+            var guidelines = new GuidelineCollection();
+
+            Assert.AreEqual("", guidelines.ToString());
+
+            guidelines.Add(new Guideline(1.5, GuidelineColor.Green));
+            Assert.AreEqual("1.5~1", guidelines.ToString());
+
+            guidelines.AddRange(new Guideline[]
+            {
+                new Guideline(3.2, GuidelineColor.Yellow),
+                new Guideline(4.7, GuidelineColor.Orange),
+                new Guideline(6.0, GuidelineColor.Green),
+                new Guideline(7.25, GuidelineColor.Green),
+                new Guideline(8.112, GuidelineColor.Yellow),
+            });
+            Assert.AreEqual("1.5~1~3.2~0.9~4.7~0.8~6~1~7.25~1~8.112~0.9", guidelines.ToString());
+        }
+        [Test]
+        public void Parse()
+        {
+            var matchedGuidelines = new Guideline[]
+            {
+                new Guideline(1.5, GuidelineColor.Green),
+                new Guideline(3.2, GuidelineColor.Yellow),
+                new Guideline(4.7, GuidelineColor.Orange),
+                new Guideline(6.0, GuidelineColor.Green),
+                new Guideline(7.25, GuidelineColor.Green),
+                new Guideline(8.112, GuidelineColor.Yellow),
+            };
+            var collection = GuidelineCollection.Parse("1.5~1~3.2~0.9~4.7~0.8~6~1~7.25~1~8.112~0.9");
+
+            for (int i = 0; i < matchedGuidelines.Length; i++)
+                Assert.IsTrue(collection[i] == matchedGuidelines[i]);
+        }
+    }
+}

--- a/GDAPI/GDAPI/Objects/GeometryDash/General/Guideline.cs
+++ b/GDAPI/GDAPI/Objects/GeometryDash/General/Guideline.cs
@@ -56,6 +56,9 @@ namespace GDAPI.Objects.GeometryDash.General
             return result;
         }
 
+        public static bool operator ==(Guideline left, Guideline right) => left.TimeStamp == right.TimeStamp && left.Color == right.Color;
+        public static bool operator !=(Guideline left, Guideline right) => left.TimeStamp != right.TimeStamp || left.Color != right.Color;
+
         /// <summary>Converts the <see cref="Guideline"/> to its string representation in the gamesave.</summary>
         public override string ToString() => $"{TimeStamp}~{Color}";
     }

--- a/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineCollection.cs
+++ b/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineCollection.cs
@@ -199,7 +199,7 @@ namespace GDAPI.Objects.GeometryDash.General
             var result = new StringBuilder();
             foreach (var g in guidelines)
                 result.Append($"{g}~");
-            return result.RemoveLast().ToString();
+            return result.RemoveLastOrNone().ToString();
         }
     }
 }


### PR DESCRIPTION
This fixes an issue where ToString would crash if the guideline collection contained no guidelines (sadly the most common case). Furthermore, tests were added for this case to ensure functionality is intended.