### PR TITLE
Exception reduction

### DIFF
--- a/GDAPI/GDAPI/Attributes/ExceptionReductorAttribute.cs
+++ b/GDAPI/GDAPI/Attributes/ExceptionReductorAttribute.cs
@@ -1,0 +1,11 @@
+﻿using GDAPI.Objects.GeometryDash.General;
+using System;
+
+namespace GDAPI.Attributes
+{
+    /// <summary>Marks an object property as only useful to avoid handling too many exceptions when initializing a new <seealso cref="LevelObject"/>.</summary>
+    [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+    public class ExceptionReductorAttribute : Attribute
+    {
+    }
+}

--- a/GDAPI/GDAPI/Objects/GeometryDash/LevelObjects/GeneralObject.cs
+++ b/GDAPI/GDAPI/Objects/GeometryDash/LevelObjects/GeneralObject.cs
@@ -267,7 +267,7 @@ namespace GDAPI.Objects.GeometryDash.LevelObjects
             get => bools[14];
             set => bools[14] = value;
         }
-        /// <summary>Unknown feawture with ID 36. Its only purpose is to avoid throwing exceptions when encountering this property, causing infinite performance costs.</summary>
+        /// <summary>Unknown feature with ID 36.</summary>
         [ObjectStringMappable(ObjectProperty.UnknownFeature36, false)]
         public bool UnknownFeature36
         {

--- a/GDAPI/GDAPI/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/BlackOrb.cs
+++ b/GDAPI/GDAPI/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/BlackOrb.cs
@@ -11,6 +11,15 @@ namespace GDAPI.Objects.GeometryDash.LevelObjects.SpecialObjects.Orbs
         [ObjectStringMappable(ObjectProperty.ObjectID)]
         public override int ObjectID => (int)OrbType.BlackOrb;
 
+        /// <summary>The Disable Rotation property of the orb, which does not exist. It serves the purpose of an exception reductor.</summary>
+        [ExceptionReductor]
+        [ObjectStringMappable(ObjectProperty.DisableRotation, false)]
+        public bool DisableRotation
+        {
+            get => false;
+            set { }
+        }
+
         /// <summary>Initializes a new instance of the <seealso cref="BlackOrb"/> class.</summary>
         public BlackOrb() : base() { }
 

--- a/GDAPI/GDAPI/Objects/GeometryDash/LevelObjects/Triggers/CollisionTrigger.cs
+++ b/GDAPI/GDAPI/Objects/GeometryDash/LevelObjects/Triggers/CollisionTrigger.cs
@@ -50,6 +50,15 @@ namespace GDAPI.Objects.GeometryDash.LevelObjects.Triggers
             set => TriggerBools[4] = value;
         }
 
+        /// <summary>The Duration property of the trigger, which does not exist. It serves the purpose of an exception reductor.</summary>
+        [ExceptionReductor]
+        [ObjectStringMappable(ObjectProperty.Duration, 0d)]
+        public double Duration
+        {
+            get => 0;
+            set { }
+        }
+
         /// <summary>Initializes a new instance of the <seealso cref="CollisionTrigger"/> class.</summary>
         public CollisionTrigger() : base() { }
         /// <summary>Initializes a new instance of the <seealso cref="CollisionTrigger"/> class.</summary>


### PR DESCRIPTION
Aside from massively cluttering the console, exceptions also reduce performance significantly, therefore throwing thousands of them on a normal basis is not the way to go.