### PR TITLE
Adjust guidelines to new findings

### DIFF
--- a/GDAPI/GDAPI.Tests/Objects/GeometryDash/GuidelineCollectionTests.cs
+++ b/GDAPI/GDAPI.Tests/Objects/GeometryDash/GuidelineCollectionTests.cs
@@ -15,31 +15,34 @@ namespace GDAPI.Tests.Objects.GeometryDash
             guidelines.Add(new Guideline(1.5, GuidelineColor.Green));
             Assert.AreEqual("1.5~1", guidelines.ToString());
 
-            guidelines.AddRange(new Guideline[]
+            guidelines.AddRange(new[]
             {
                 new Guideline(3.2, GuidelineColor.Yellow),
                 new Guideline(4.7, GuidelineColor.Orange),
                 new Guideline(6.0, GuidelineColor.Green),
                 new Guideline(7.25, GuidelineColor.Green),
-                new Guideline(8.112, GuidelineColor.Yellow),
+                new Guideline(8.112, GuidelineColor.Yellow)
             });
-            Assert.AreEqual("1.5~1~3.2~0.9~4.7~0.8~6~1~7.25~1~8.112~0.9", guidelines.ToString());
+
+            Assert.AreEqual("1.5~1~3.2~0.9~4.7~1.1~6~1~7.25~1~8.112~0.9", guidelines.ToString());
         }
+
         [Test]
         public void Parse()
         {
-            var matchedGuidelines = new Guideline[]
+            var matchedGuidelines = new[]
             {
                 new Guideline(1.5, GuidelineColor.Green),
                 new Guideline(3.2, GuidelineColor.Yellow),
                 new Guideline(4.7, GuidelineColor.Orange),
                 new Guideline(6.0, GuidelineColor.Green),
                 new Guideline(7.25, GuidelineColor.Green),
-                new Guideline(8.112, GuidelineColor.Yellow),
+                new Guideline(8.112, GuidelineColor.Yellow)
             };
-            var collection = GuidelineCollection.Parse("1.5~1~3.2~0.9~4.7~0.8~6~1~7.25~1~8.112~0.9");
 
-            for (int i = 0; i < matchedGuidelines.Length; i++)
+            var collection = GuidelineCollection.Parse("1.5~1~3.2~0.9~4.7~1.1~6~1~7.25~1~8.112~0.9");
+
+            for (var i = 0; i < matchedGuidelines.Length; i++)
                 Assert.IsTrue(collection[i] == matchedGuidelines[i]);
         }
     }

--- a/GDAPI/GDAPI/Objects/GeometryDash/General/Guideline.cs
+++ b/GDAPI/GDAPI/Objects/GeometryDash/General/Guideline.cs
@@ -5,23 +5,12 @@ namespace GDAPI.Objects.GeometryDash.General
     /// <summary>Contains information about a level guideline.</summary>
     public class Guideline : IComparable<Guideline>
     {
-        /// <summary>The timestamp of the guideline.</summary>
-        public double TimeStamp { get; set; }
-        /// <summary>The color of the guideline.</summary>
-        public GuidelineColor Color { get; set; }
+        /// <summary>Creates a new empty instance of the <seealso cref="Guideline" /> class.</summary>
+        public Guideline()
+        {
+        }
 
-        /// <summary>Determines whether the guideline color is transparent.</summary>
-        public bool IsTransparent => Color.IsTransparent;
-        /// <summary>Determines whether the guideline color is orange.</summary>
-        public bool IsOrange => Color.IsOrange;
-        /// <summary>Determines whether the guideline color is yellow.</summary>
-        public bool IsYellow => Color.IsYellow;
-        /// <summary>Determines whether the guideline color is green.</summary>
-        public bool IsGreen => Color.IsGreen;
-
-        /// <summary>Creates a new empty instance of the <seealso cref="Guideline"/> class.</summary>
-        public Guideline() { }
-        /// <summary>Creates a new instance of the <seealso cref="Guideline"/> class.</summary>
+        /// <summary>Creates a new instance of the <seealso cref="Guideline" /> class.</summary>
         /// <param name="timeStamp">The timestamp of the guideline.</param>
         /// <param name="color">The color of the guideline.</param>
         public Guideline(double timeStamp, GuidelineColor color)
@@ -29,7 +18,8 @@ namespace GDAPI.Objects.GeometryDash.General
             TimeStamp = timeStamp;
             Color = color;
         }
-        /// <summary>Creates a new instance of the <seealso cref="Guideline"/> class.</summary>
+
+        /// <summary>Creates a new instance of the <seealso cref="Guideline" /> class.</summary>
         /// <param name="timeStamp">The timestamp of the guideline.</param>
         /// <param name="color">The color of the guideline.</param>
         public Guideline(float timeStamp, GuidelineColor color)
@@ -37,29 +27,50 @@ namespace GDAPI.Objects.GeometryDash.General
             TimeStamp = timeStamp;
             Color = color;
         }
-        /// <summary>Creates a new instance of the <seealso cref="Guideline"/> class.</summary>
+
+        /// <summary>Creates a new instance of the <seealso cref="Guideline" /> class.</summary>
         /// <param name="timeStamp">The timestamp of the guideline.</param>
         /// <param name="color">The color of the guideline.</param>
         public Guideline(decimal timeStamp, GuidelineColor color)
         {
-            TimeStamp = (double)timeStamp;
+            TimeStamp = (double) timeStamp;
             Color = color;
         }
 
-        /// <summary>Compares this <seealso cref="Guideline"/> to another primarily based on their time stamps and secondarily on their colors.</summary>
-        /// <param name="other">The other <seealso cref="Guideline"/> to compare this to.</param>
+        /// <summary>The timestamp of the guideline.</summary>
+        public double TimeStamp { get; set; }
+
+        /// <summary>The color of the guideline.</summary>
+        public GuidelineColor Color { get; set; }
+
+        /// <summary>Determines whether the guideline color is orange.</summary>
+        public bool IsOrange => Color.IsOrange;
+
+        /// <summary>Determines whether the guideline color is yellow.</summary>
+        public bool IsYellow => Color.IsYellow;
+
+        /// <summary>Determines whether the guideline color is green.</summary>
+        public bool IsGreen => Color.IsGreen;
+
+        /// <summary>Compares this <seealso cref="Guideline" /> to another primarily based on their time stamps and secondarily on their colors.</summary>
+        /// <param name="other">The other <seealso cref="Guideline" /> to compare this to.</param>
         public int CompareTo(Guideline other)
         {
-            int result = TimeStamp.CompareTo(other.TimeStamp);
+            var result = TimeStamp.CompareTo(other.TimeStamp);
+
             if (result == 0)
                 return Color.CompareTo(other.Color);
+
             return result;
         }
 
-        public static bool operator ==(Guideline left, Guideline right) => left.TimeStamp == right.TimeStamp && left.Color == right.Color;
-        public static bool operator !=(Guideline left, Guideline right) => left.TimeStamp != right.TimeStamp || left.Color != right.Color;
+        public static bool operator ==(Guideline left, Guideline right) =>
+            left.TimeStamp == right.TimeStamp && left.Color == right.Color;
 
-        /// <summary>Converts the <see cref="Guideline"/> to its string representation in the gamesave.</summary>
+        public static bool operator !=(Guideline left, Guideline right) =>
+            left.TimeStamp != right.TimeStamp || left.Color != right.Color;
+
+        /// <summary>Converts the <see cref="Guideline" /> to its string representation in the gamesave.</summary>
         public override string ToString() => $"{TimeStamp}~{Color}";
     }
 }

--- a/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineCollection.cs
+++ b/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineCollection.cs
@@ -11,195 +11,235 @@ namespace GDAPI.Objects.GeometryDash.General
     /// <summary>Represents a collection of guidelines.</summary>
     public class GuidelineCollection : IEnumerable<Guideline>
     {
-        private SortedList<Guideline> guidelines;
         private Dictionary<GuidelineColor, int> colors;
+        private SortedList<Guideline> guidelines;
+
+        /// <summary>Initializes a new instance of the <seealso cref="GuidelineCollection" /> class.</summary>
+        public GuidelineCollection() : this(new List<Guideline>())
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <seealso cref="GuidelineCollection" /> class.</summary>
+        /// <param name="g">The guidelines to create the collection out of.</param>
+        public GuidelineCollection(IEnumerable<Guideline> g)
+            : this(g, true)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <seealso cref="GuidelineCollection" /> class.</summary>
+        /// <param name="g">The guidelines to create the collection out of.</param>
+        /// <param name="analyzeColors">Determines whether the guideline color counts will be cached.</param>
+        private GuidelineCollection(IEnumerable<Guideline> g, bool analyzeColors)
+        {
+            guidelines = new SortedList<Guideline>(g);
+
+            if (analyzeColors)
+                AnalyzeColors();
+        }
 
         /// <summary>The count of the guideline collection.</summary>
         public int Count => guidelines.Count;
+
         /// <summary>The time stamps of the guidelines.</summary>
         public List<double> TimeStamps
         {
             get
             {
                 var t = new List<double>();
+
                 foreach (var g in guidelines)
                     t.Add(g.TimeStamp);
+
                 return t;
             }
         }
 
-        /// <summary>Retrieves the cached count of transparent guidelines in this collection.</summary>
-        public int TransparentGuidelineCount => colors[GuidelineColor.Transparent];
         /// <summary>Retrieves the cached count of orange guidelines in this collection.</summary>
         public int OrangeGuidelineCount => colors[GuidelineColor.Orange];
+
         /// <summary>Retrieves the cached count of yellow guidelines in this collection.</summary>
         public int YellowGuidelineCount => colors[GuidelineColor.Yellow];
+
         /// <summary>Retrieves the cached count of green guidelines in this collection.</summary>
         public int GreenGuidelineCount => colors[GuidelineColor.Green];
 
-        /// <summary>Retrieves a collection consisting of the transparent guidelines from this collection.</summary>
-        public GuidelineCollection TransparentGuidelines => GetColorSpecificGuidelines(GuidelineColor.Transparent);
         /// <summary>Retrieves a collection consisting of the orange guidelines from this collection.</summary>
         public GuidelineCollection OrangeGuidelines => GetColorSpecificGuidelines(GuidelineColor.Orange);
+
         /// <summary>Retrieves a collection consisting of the yellow guidelines from this collection.</summary>
         public GuidelineCollection YellowGuidelines => GetColorSpecificGuidelines(GuidelineColor.Yellow);
+
         /// <summary>Retrieves a collection consisting of the green guidelines from this collection.</summary>
         public GuidelineCollection GreenGuidelines => GetColorSpecificGuidelines(GuidelineColor.Green);
 
-        /// <summary>Initializes a new instance of the <seealso cref="GuidelineCollection"/> class.</summary>
-        public GuidelineCollection() : this(new List<Guideline>()) { }
-        /// <summary>Initializes a new instance of the <seealso cref="GuidelineCollection"/> class.</summary>
-        /// <param name="g">The guidelines to create the collection out of.</param>
-        public GuidelineCollection(IEnumerable<Guideline> g)
-            : this(g, true) { }
-        /// <summary>Initializes a new instance of the <seealso cref="GuidelineCollection"/> class.</summary>
-        /// <param name="g">The guidelines to create the collection out of.</param>
-        /// <param name="analyzeColors">Determines whether the guideline color counts will be cached.</param>
-        private GuidelineCollection(IEnumerable<Guideline> g, bool analyzeColors)
-        {
-            guidelines = new SortedList<Guideline>(g);
-            if (analyzeColors)
-                AnalyzeColors();
-        }
+        /// <summary>Gets the <seealso cref="Guideline" /> at a specified index.</summary>
+        /// <param name="index">The index of the <seealso cref="Guideline" /> to get.</param>
+        public Guideline this[int index] => guidelines[index];
 
-        /// <summary>Adds a <seealso cref="Guideline"/> to the <seealso cref="GuidelineCollection"/> and returns the instance of the <seealso cref="GuidelineCollection"/>.</summary>
-        /// <param name="guideline">The guideline to add to the <seealso cref="GuidelineCollection"/>.</param>
+        public IEnumerator<Guideline> GetEnumerator() => guidelines.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => guidelines.GetEnumerator();
+
+        /// <summary>Adds a <seealso cref="Guideline" /> to the <seealso cref="GuidelineCollection" /> and returns the instance of the <seealso cref="GuidelineCollection" />.</summary>
+        /// <param name="guideline">The guideline to add to the <seealso cref="GuidelineCollection" />.</param>
         public GuidelineCollection Add(Guideline guideline)
         {
             guidelines.Add(guideline);
             colors[guideline.Color]++;
+
             return this;
         }
-        /// <summary>Adds a collection of guidelines from the <seealso cref="GuidelineCollection"/>.</summary>
+
+        /// <summary>Adds a collection of guidelines from the <seealso cref="GuidelineCollection" />.</summary>
         /// <param name="g">The guidelines to add.</param>
         public GuidelineCollection AddRange(IEnumerable<Guideline> g)
         {
             guidelines.Add(g);
+
             foreach (var guideline in g)
                 colors[guideline.Color]++;
+
             return this;
         }
-        /// <summary>Adds a collection of guidelines from the <seealso cref="GuidelineCollection"/>.</summary>
+
+        /// <summary>Adds a collection of guidelines from the <seealso cref="GuidelineCollection" />.</summary>
         /// <param name="guidelines">The guidelines to add.</param>
         public GuidelineCollection AddRange(GuidelineCollection guidelines)
         {
             guidelines.AddRange(guidelines.guidelines);
+
             foreach (var c in guidelines.colors)
                 colors[c.Key] += c.Value;
+
             return this;
         }
-        /// <summary>Removes a <seealso cref="Guideline"/> from the <seealso cref="GuidelineCollection"/> and returns the instance of the <seealso cref="GuidelineCollection"/>.</summary>
-        /// <param name="guideline">The guideline to remove from the <seealso cref="GuidelineCollection"/>.</param>
+
+        /// <summary>Removes a <seealso cref="Guideline" /> from the <seealso cref="GuidelineCollection" /> and returns the instance of the <seealso cref="GuidelineCollection" />.</summary>
+        /// <param name="guideline">The guideline to remove from the <seealso cref="GuidelineCollection" />.</param>
         public GuidelineCollection Remove(Guideline guideline)
         {
             guidelines.Remove(guideline);
             colors[guideline.Color]--;
+
             return this;
         }
-        /// <summary>Removes the <seealso cref="Guideline"/> at the specified index from the <seealso cref="GuidelineCollection"/> and returns the instance of the <seealso cref="GuidelineCollection"/>.</summary>
-        /// <param name="index">The index of the guideline to remove from the <seealso cref="GuidelineCollection"/>.</param>
+
+        /// <summary>Removes the <seealso cref="Guideline" /> at the specified index from the <seealso cref="GuidelineCollection" /> and returns the instance of the <seealso cref="GuidelineCollection" />.</summary>
+        /// <param name="index">The index of the guideline to remove from the <seealso cref="GuidelineCollection" />.</param>
         public GuidelineCollection RemoveAt(int index)
         {
             colors[guidelines[index].Color]--;
             guidelines.RemoveAt(index);
+
             return this;
         }
-        /// <summary>Clears the <seealso cref="GuidelineCollection"/> and returns the instance of the <seealso cref="GuidelineCollection"/>.</summary>
-        /// <param name="index">The index of the guideline to remove from the <seealso cref="GuidelineCollection"/>.</param>
+
+        /// <summary>Clears the <seealso cref="GuidelineCollection" /> and returns the instance of the <seealso cref="GuidelineCollection" />.</summary>
+        /// <param name="index">The index of the guideline to remove from the <seealso cref="GuidelineCollection" />.</param>
         public GuidelineCollection Clear()
         {
             guidelines.Clear();
             InitializeColorDictionary();
+
             return this;
         }
-        /// <summary>Adds a <seealso cref="Guideline"/> into the <seealso cref="GuidelineCollection"/> and returns the instance of the <seealso cref="GuidelineCollection"/>.</summary>
-        /// <param name="timeStamp">The timestamp of the <seealso cref="Guideline"/>.</param>
-        /// <param name="color">The color of the <seealso cref="Guideline"/>.</param>
+
+        /// <summary>Adds a <seealso cref="Guideline" /> into the <seealso cref="GuidelineCollection" /> and returns the instance of the <seealso cref="GuidelineCollection" />.</summary>
+        /// <param name="timeStamp">The timestamp of the <seealso cref="Guideline" />.</param>
+        /// <param name="color">The color of the <seealso cref="Guideline" />.</param>
         public GuidelineCollection Add(double timeStamp, double color) => Add(new Guideline(timeStamp, color));
-        /// <summary>Removes the duplicated guidelines and returns the instance of the <seealso cref="GuidelineCollection"/>.</summary>
+
+        /// <summary>Removes the duplicated guidelines and returns the instance of the <seealso cref="GuidelineCollection" />.</summary>
         public GuidelineCollection RemoveDuplicatedGuidelines()
         {
             guidelines = guidelines.RemoveDuplicates();
             AnalyzeColors();
+
             return this;
         }
+
         /// <summary>Returns the index of the first guideline whose time stamp is not greater than the provided time stamp.</summary>
         /// <param name="timeStamp">The time stamp to exceed.</param>
         public int GetFirstIndexAfterTimeStamp(double timeStamp)
         {
-            int min = 0;
-            int max = guidelines.Count;
-            int mid = 0;
+            var min = 0;
+            var max = guidelines.Count;
+            var mid = 0;
+
             while (min < max)
             {
                 mid = (min + max) / 2;
+
                 if (timeStamp == guidelines[mid].TimeStamp)
                     return mid;
+
                 if (timeStamp < guidelines[mid].TimeStamp)
                     min = mid + 1;
                 else
                     max = mid;
             }
+
             return mid;
         }
 
-        public IEnumerator<Guideline> GetEnumerator() => guidelines.GetEnumerator();
-        IEnumerator IEnumerable.GetEnumerator() => guidelines.GetEnumerator();
+        /// <summary>Parses the guideline string into a <seealso cref="GuidelineCollection" />.</summary>
+        /// <param name="guidelineString">The guideline string to parse.</param>
+        public static GuidelineCollection Parse(string guidelineString)
+        {
+            var guidelines = new GuidelineCollection();
+
+            if (!string.IsNullOrEmpty(guidelineString))
+            {
+                if (guidelineString.EndsWith("~"))
+                    guidelineString = guidelineString.Remove(guidelineString.Length - 1);
+
+                var s = guidelineString.Split('~');
+
+                for (var i = 0; i < s.Length; i += 2)
+                    guidelines.Add(ToDouble(s[i]), ToDouble(s[i + 1]));
+            }
+
+            return guidelines;
+        }
+
+        /// <summary>Returns the guideline string of the <seealso cref="GuidelineCollection" />.</summary>
+        public override string ToString()
+        {
+            var result = new StringBuilder();
+
+            foreach (var g in guidelines)
+                result.Append($"{g}~");
+
+            return result.RemoveLastOrNone().ToString();
+        }
 
         #region Private stuff
         private void AnalyzeColors()
         {
             InitializeColorDictionary();
-            for (int i = 0; i < guidelines.Count; i++)
+
+            for (var i = 0; i < guidelines.Count; i++)
                 colors[guidelines[i].Color]++;
         }
+
         private void InitializeColorDictionary()
         {
             colors = new Dictionary<GuidelineColor, int>
             {
-                { GuidelineColor.Transparent, 0 },
-                { GuidelineColor.Orange, 0 },
-                { GuidelineColor.Yellow, 0 },
-                { GuidelineColor.Green, 0 },
+                {GuidelineColor.Orange, 0},
+                {GuidelineColor.Yellow, 0},
+                {GuidelineColor.Green, 0}
             };
         }
+
         private GuidelineCollection GetColorSpecificGuidelines(GuidelineColor color)
         {
             var collection = new GuidelineCollection(guidelines.Where(g => g.Color == color), false);
             collection.colors[color] = colors[color];
+
             return collection;
         }
 
         private int FindIndexToInsertGuideline(Guideline g) => GetFirstIndexAfterTimeStamp(g.TimeStamp);
         #endregion
-
-        /// <summary>Parses the guideline string into a <seealso cref="GuidelineCollection"/>.</summary>
-        /// <param name="guidelineString">The guideline string to parse.</param>
-        public static GuidelineCollection Parse(string guidelineString)
-        {
-            var guidelines = new GuidelineCollection();
-            if (!string.IsNullOrEmpty(guidelineString))
-            {
-                if (guidelineString.EndsWith("~"))
-                    guidelineString = guidelineString.Remove(guidelineString.Length - 1);
-                string[] s = guidelineString.Split('~');
-                for (int i = 0; i < s.Length; i += 2)
-                    guidelines.Add(ToDouble(s[i]), ToDouble(s[i + 1]));
-            }
-            return guidelines;
-        }
-
-        /// <summary>Gets the <seealso cref="Guideline"/> at a specified index.</summary>
-        /// <param name="index">The index of the <seealso cref="Guideline"/> to get.</param>
-        public Guideline this[int index] => guidelines[index];
-
-        /// <summary>Returns the guideline string of the <seealso cref="GuidelineCollection"/>.</summary>
-        public override string ToString()
-        {
-            var result = new StringBuilder();
-            foreach (var g in guidelines)
-                result.Append($"{g}~");
-            return result.RemoveLastOrNone().ToString();
-        }
     }
 }

--- a/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineColor.cs
+++ b/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineColor.cs
@@ -5,70 +5,82 @@ namespace GDAPI.Objects.GeometryDash.General
     /// <summary>Represents the color of a guideline.</summary>
     public struct GuidelineColor : IComparable<GuidelineColor>
     {
-        /// <summary>Represents the value of the orange color in the guideline.</summary>
-        public const float TransparentValue = 0.7f;
         /// <summary>Represents the value of the yellow color in the guideline.</summary>
-        public const float OrangeValue = 0.8f;
-        /// <summary>Represents the value of the green color in the guideline.</summary>
         public const float YellowValue = 0.9f;
-        /// <summary>Represents the value of the transparent color in the guideline. It is a hidden game feature, where invisible guidelines may be created.</summary>
+
+        /// <summary>Represents the value of the green color in the guideline.</summary>
         public const float GreenValue = 1f;
 
-        /// <summary>An instance of the transparent guideline color.</summary>
-        public static readonly GuidelineColor Transparent = new GuidelineColor(TransparentValue);
-        /// <summary>An instance of the orange guideline color.</summary>
-        public static readonly GuidelineColor Orange = new GuidelineColor(OrangeValue);
+        /// <summary>Represents the value of the orange color in the guideline.</summary>
+        /// <remarks>This can be any value but chosen to be 1.1 for simplicity.</remarks>
+        public const float OrangeValue = 1.1f;
+
         /// <summary>An instance of the yellow guideline color.</summary>
         public static readonly GuidelineColor Yellow = new GuidelineColor(YellowValue);
+
         /// <summary>An instance of the green guideline color.</summary>
         public static readonly GuidelineColor Green = new GuidelineColor(GreenValue);
 
-        private float col;
+        /// <summary>An instance of the orange guideline color.</summary>
+        public static readonly GuidelineColor Orange = new GuidelineColor(OrangeValue);
 
-        /// <summary>Determines whether the guideline color is transparent.</summary>
-        public bool IsTransparent => col == TransparentValue;
-        /// <summary>Determines whether the guideline color is orange.</summary>
-        public bool IsOrange => col == OrangeValue;
+        private readonly float col;
+
         /// <summary>Determines whether the guideline color is yellow.</summary>
         public bool IsYellow => col == YellowValue;
+
         /// <summary>Determines whether the guideline color is green.</summary>
         public bool IsGreen => col == GreenValue;
 
-        /// <summary>Initializes a new instance of the <seealso cref="GuidelineColor"/> struct.</summary>
-        /// <param name="color">The color value to use.</param>
-        public GuidelineColor(float color) => col = color;
-        /// <summary>Initializes a new instance of the <seealso cref="GuidelineColor"/> struct.</summary>
-        /// <param name="color">The color value to use.</param>
-        public GuidelineColor(double color) => col = (float)color;
-        /// <summary>Initializes a new instance of the <seealso cref="GuidelineColor"/> struct.</summary>
-        /// <param name="color">The color value to use.</param>
-        public GuidelineColor(decimal color) => col = (float)color;
+        /// <summary>Determines whether the guideline color is orange.</summary>
+        public bool IsOrange => col > GreenValue;
 
-        /// <summary>Compares this <seealso cref="GuidelineColor"/> to another based on their color value.</summary>
-        /// <param name="other">The other <seealso cref="GuidelineColor"/> to compare this to.</param>
+        /// <summary>Initializes a new instance of the <seealso cref="GuidelineColor" /> struct.</summary>
+        /// <param name="color">The color value to use.</param>
+        public GuidelineColor(float color)
+        {
+            col = color;
+        }
+
+        /// <summary>Initializes a new instance of the <seealso cref="GuidelineColor" /> struct.</summary>
+        /// <param name="color">The color value to use.</param>
+        public GuidelineColor(double color)
+        {
+            col = (float) color;
+        }
+
+        /// <summary>Initializes a new instance of the <seealso cref="GuidelineColor" /> struct.</summary>
+        /// <param name="color">The color value to use.</param>
+        public GuidelineColor(decimal color)
+        {
+            col = (float) color;
+        }
+
+        /// <summary>Compares this <seealso cref="GuidelineColor" /> to another based on their color value.</summary>
+        /// <param name="other">The other <seealso cref="GuidelineColor" /> to compare this to.</param>
         public int CompareTo(GuidelineColor other) => col.CompareTo(other.col);
 
         public static implicit operator GuidelineColor(float color) => new GuidelineColor(color);
         public static implicit operator GuidelineColor(double color) => new GuidelineColor(color);
         public static implicit operator GuidelineColor(decimal color) => new GuidelineColor(color);
-
         public static explicit operator float(GuidelineColor color) => color.col;
         public static explicit operator double(GuidelineColor color) => color.col;
-        public static explicit operator decimal(GuidelineColor color) => (decimal)color.col;
-
+        public static explicit operator decimal(GuidelineColor color) => (decimal) color.col;
         public static bool operator ==(GuidelineColor left, GuidelineColor right) => left.col == right.col;
         public static bool operator !=(GuidelineColor left, GuidelineColor right) => left.col != right.col;
 
-        /// <summary>Parses the <seealso cref="GuidelineColor"/> from a string representation of a <seealso cref="float"/>.</summary>
+        /// <summary>Parses the <seealso cref="GuidelineColor" /> from a string representation of a <seealso cref="float" />.</summary>
         /// <param name="s">The string to parse.</param>
         public static GuidelineColor Parse(string s) => float.Parse(s);
 
-        /// <summary>Returns the string representation of this <seealso cref="GuidelineColor"/>'s raw color value.</summary>
+        /// <summary>Returns the string representation of this <seealso cref="GuidelineColor" />'s raw color value.</summary>
         public override string ToString() => col.ToString();
-        /// <summary>Determines whether this <seealso cref="GuidelineColor"/> equals another object.</summary>
+
+        /// <summary>Determines whether this <seealso cref="GuidelineColor" /> equals another object.</summary>
         /// <param name="obj">The other object to determine equality with.</param>
-        public override bool Equals(object obj) => col.Equals(((GuidelineColor)obj).col);
-        /// <summary>Gets the hash code of this <seealso cref="GuidelineColor"/> based on the raw color value.</summary>
+        public override bool Equals(object obj) => col.Equals(((GuidelineColor) obj).col);
+
+        /// <summary>Gets the hash code of this <seealso cref="GuidelineColor" /> based on the raw color value.</summary>
         public override int GetHashCode() => col.GetHashCode();
     }
 }


### PR DESCRIPTION
Closes #57.
Based on a private talk between me and AlFas, we have set out to completely remove the transparent guideline as the information was not completely certain, and throughout some testing he has discovered the exact behavior.

This also changes the orange value to be higher than `0.8`, as it's discovered that if you place a value of `1.0` to `float.PositiveInfinity`, you would get an orange guideline.