### PR TITLE
Adjust guidelines to new findings

### DIFF
--- a/GDAPI/GDAPI.Tests/Objects/GeometryDash/GuidelineCollectionTests.cs
+++ b/GDAPI/GDAPI.Tests/Objects/GeometryDash/GuidelineCollectionTests.cs
@@ -23,7 +23,7 @@ namespace GDAPI.Tests.Objects.GeometryDash
                 new Guideline(7.25, GuidelineColor.Green),
                 new Guideline(8.112, GuidelineColor.Yellow),
             });
-            Assert.AreEqual("1.5~1~3.2~0.9~4.7~0.8~6~1~7.25~1~8.112~0.9", guidelines.ToString());
+            Assert.AreEqual("1.5~1~3.2~0.9~4.7~1.1~6~1~7.25~1~8.112~0.9", guidelines.ToString());
         }
         [Test]
         public void Parse()
@@ -37,7 +37,7 @@ namespace GDAPI.Tests.Objects.GeometryDash
                 new Guideline(7.25, GuidelineColor.Green),
                 new Guideline(8.112, GuidelineColor.Yellow),
             };
-            var collection = GuidelineCollection.Parse("1.5~1~3.2~0.9~4.7~0.8~6~1~7.25~1~8.112~0.9");
+            var collection = GuidelineCollection.Parse("1.5~1~3.2~0.9~4.7~1.1~6~1~7.25~1~8.112~0.9");
 
             for (int i = 0; i < matchedGuidelines.Length; i++)
                 Assert.IsTrue(collection[i] == matchedGuidelines[i]);

--- a/GDAPI/GDAPI.Tests/Objects/GeometryDash/GuidelineCollectionTests.cs
+++ b/GDAPI/GDAPI.Tests/Objects/GeometryDash/GuidelineCollectionTests.cs
@@ -23,7 +23,7 @@ namespace GDAPI.Tests.Objects.GeometryDash
                 new Guideline(7.25, GuidelineColor.Green),
                 new Guideline(8.112, GuidelineColor.Yellow),
             });
-            Assert.AreEqual("1.5~1~3.2~0.9~4.7~1.1~6~1~7.25~1~8.112~0.9", guidelines.ToString());
+            Assert.AreEqual("1.5~1~3.2~0.9~4.7~0.8~6~1~7.25~1~8.112~0.9", guidelines.ToString());
         }
         [Test]
         public void Parse()
@@ -37,7 +37,7 @@ namespace GDAPI.Tests.Objects.GeometryDash
                 new Guideline(7.25, GuidelineColor.Green),
                 new Guideline(8.112, GuidelineColor.Yellow),
             };
-            var collection = GuidelineCollection.Parse("1.5~1~3.2~0.9~4.7~1.1~6~1~7.25~1~8.112~0.9");
+            var collection = GuidelineCollection.Parse("1.5~1~3.2~0.9~4.7~0.8~6~1~7.25~1~8.112~0.9");
 
             for (int i = 0; i < matchedGuidelines.Length; i++)
                 Assert.IsTrue(collection[i] == matchedGuidelines[i]);

--- a/GDAPI/GDAPI/Objects/GeometryDash/General/Guideline.cs
+++ b/GDAPI/GDAPI/Objects/GeometryDash/General/Guideline.cs
@@ -10,8 +10,6 @@ namespace GDAPI.Objects.GeometryDash.General
         /// <summary>The color of the guideline.</summary>
         public GuidelineColor Color { get; set; }
 
-        /// <summary>Determines whether the guideline color is transparent.</summary>
-        public bool IsTransparent => Color.IsTransparent;
         /// <summary>Determines whether the guideline color is orange.</summary>
         public bool IsOrange => Color.IsOrange;
         /// <summary>Determines whether the guideline color is yellow.</summary>

--- a/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineCollection.cs
+++ b/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineCollection.cs
@@ -28,8 +28,6 @@ namespace GDAPI.Objects.GeometryDash.General
             }
         }
 
-        /// <summary>Retrieves the cached count of transparent guidelines in this collection.</summary>
-        public int TransparentGuidelineCount => colors[GuidelineColor.Transparent];
         /// <summary>Retrieves the cached count of orange guidelines in this collection.</summary>
         public int OrangeGuidelineCount => colors[GuidelineColor.Orange];
         /// <summary>Retrieves the cached count of yellow guidelines in this collection.</summary>
@@ -37,8 +35,6 @@ namespace GDAPI.Objects.GeometryDash.General
         /// <summary>Retrieves the cached count of green guidelines in this collection.</summary>
         public int GreenGuidelineCount => colors[GuidelineColor.Green];
 
-        /// <summary>Retrieves a collection consisting of the transparent guidelines from this collection.</summary>
-        public GuidelineCollection TransparentGuidelines => GetColorSpecificGuidelines(GuidelineColor.Transparent);
         /// <summary>Retrieves a collection consisting of the orange guidelines from this collection.</summary>
         public GuidelineCollection OrangeGuidelines => GetColorSpecificGuidelines(GuidelineColor.Orange);
         /// <summary>Retrieves a collection consisting of the yellow guidelines from this collection.</summary>
@@ -157,7 +153,6 @@ namespace GDAPI.Objects.GeometryDash.General
         {
             colors = new Dictionary<GuidelineColor, int>
             {
-                { GuidelineColor.Transparent, 0 },
                 { GuidelineColor.Orange, 0 },
                 { GuidelineColor.Yellow, 0 },
                 { GuidelineColor.Green, 0 },

--- a/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineColor.cs
+++ b/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineColor.cs
@@ -5,19 +5,19 @@ namespace GDAPI.Objects.GeometryDash.General
     /// <summary>Represents the color of a guideline.</summary>
     public struct GuidelineColor : IComparable<GuidelineColor>
     {
+        /// <summary>Represents the value of the orange color in the guideline.</summary>
+        public const float OrangeValue = 0.8f;
         /// <summary>Represents the value of the yellow color in the guideline.</summary>
         public const float YellowValue = 0.9f;
         /// <summary>Represents the value of the green color in the guideline.</summary>
         public const float GreenValue = 1f;
-        /// <summary>Represents the value of the orange color in the guideline.</summary>
-        public const float OrangeValue = 0.8f;
 
+        /// <summary>An instance of the orange guideline color.</summary>
+        public static readonly GuidelineColor Orange = new GuidelineColor(OrangeValue);
         /// <summary>An instance of the yellow guideline color.</summary>
         public static readonly GuidelineColor Yellow = new GuidelineColor(YellowValue);
         /// <summary>An instance of the green guideline color.</summary>
         public static readonly GuidelineColor Green = new GuidelineColor(GreenValue);
-        /// <summary>An instance of the orange guideline color.</summary>
-        public static readonly GuidelineColor Orange = new GuidelineColor(OrangeValue);
 
         private float col;
 

--- a/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineColor.cs
+++ b/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineColor.cs
@@ -10,8 +10,7 @@ namespace GDAPI.Objects.GeometryDash.General
         /// <summary>Represents the value of the green color in the guideline.</summary>
         public const float GreenValue = 1f;
         /// <summary>Represents the value of the orange color in the guideline.</summary>
-        /// <remarks>This can be any value but chosen to be 1.1 for simplicity.</remarks>
-        public const float OrangeValue = 1.1f;
+        public const float OrangeValue = 0.8f;
 
         /// <summary>An instance of the yellow guideline color.</summary>
         public static readonly GuidelineColor Yellow = new GuidelineColor(YellowValue);

--- a/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineColor.cs
+++ b/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineColor.cs
@@ -5,30 +5,25 @@ namespace GDAPI.Objects.GeometryDash.General
     /// <summary>Represents the color of a guideline.</summary>
     public struct GuidelineColor : IComparable<GuidelineColor>
     {
-        /// <summary>Represents the value of the orange color in the guideline.</summary>
-        public const float TransparentValue = 0.7f;
         /// <summary>Represents the value of the yellow color in the guideline.</summary>
-        public const float OrangeValue = 0.8f;
-        /// <summary>Represents the value of the green color in the guideline.</summary>
         public const float YellowValue = 0.9f;
-        /// <summary>Represents the value of the transparent color in the guideline. It is a hidden game feature, where invisible guidelines may be created.</summary>
+        /// <summary>Represents the value of the green color in the guideline.</summary>
         public const float GreenValue = 1f;
+        /// <summary>Represents the value of the orange color in the guideline.</summary>
+        public const float OrangeValue = 1.0f;
 
-        /// <summary>An instance of the transparent guideline color.</summary>
-        public static readonly GuidelineColor Transparent = new GuidelineColor(TransparentValue);
-        /// <summary>An instance of the orange guideline color.</summary>
-        public static readonly GuidelineColor Orange = new GuidelineColor(OrangeValue);
         /// <summary>An instance of the yellow guideline color.</summary>
         public static readonly GuidelineColor Yellow = new GuidelineColor(YellowValue);
         /// <summary>An instance of the green guideline color.</summary>
         public static readonly GuidelineColor Green = new GuidelineColor(GreenValue);
+        /// <summary>An instance of the orange guideline color.</summary>
+        public static readonly GuidelineColor Orange = new GuidelineColor(OrangeValue + 0.1f);
 
         private float col;
 
-        /// <summary>Determines whether the guideline color is transparent.</summary>
-        public bool IsTransparent => col == TransparentValue;
         /// <summary>Determines whether the guideline color is orange.</summary>
-        public bool IsOrange => col == OrangeValue;
+        /// <remarks>Value will return true IF the color value is higher than 1.0</remarks>
+        public bool IsOrange => col > OrangeValue;
         /// <summary>Determines whether the guideline color is yellow.</summary>
         public bool IsYellow => col == YellowValue;
         /// <summary>Determines whether the guideline color is green.</summary>

--- a/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineColor.cs
+++ b/GDAPI/GDAPI/Objects/GeometryDash/General/GuidelineColor.cs
@@ -10,20 +10,20 @@ namespace GDAPI.Objects.GeometryDash.General
         /// <summary>Represents the value of the green color in the guideline.</summary>
         public const float GreenValue = 1f;
         /// <summary>Represents the value of the orange color in the guideline.</summary>
-        public const float OrangeValue = 1.0f;
+        /// <remarks>This can be any value but chosen to be 1.1 for simplicity.</remarks>
+        public const float OrangeValue = 1.1f;
 
         /// <summary>An instance of the yellow guideline color.</summary>
         public static readonly GuidelineColor Yellow = new GuidelineColor(YellowValue);
         /// <summary>An instance of the green guideline color.</summary>
         public static readonly GuidelineColor Green = new GuidelineColor(GreenValue);
         /// <summary>An instance of the orange guideline color.</summary>
-        public static readonly GuidelineColor Orange = new GuidelineColor(OrangeValue + 0.1f);
+        public static readonly GuidelineColor Orange = new GuidelineColor(OrangeValue);
 
         private float col;
 
         /// <summary>Determines whether the guideline color is orange.</summary>
-        /// <remarks>Value will return true IF the color value is higher than 1.0</remarks>
-        public bool IsOrange => col > OrangeValue;
+        public bool IsOrange => col == 0 || (col >= 0.8 && col != YellowValue && col != GreenValue);
         /// <summary>Determines whether the guideline color is yellow.</summary>
         public bool IsYellow => col == YellowValue;
         /// <summary>Determines whether the guideline color is green.</summary>


### PR DESCRIPTION
Closes #57.
Based on a private talk between me and AlFas, we have set out to completely remove the transparent guideline as the information was not completely certain, and throughout some testing he has discovered the exact behavior.

This also changes the orange value to be higher than 0.8, as it's discovered that if you place a value of 1.0 to float.PositiveInfinity, you would get an orange guideline.